### PR TITLE
feature: Add feature flag to use rust-tls instead of openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,6 @@ rand = { version = "0.8.3" }
 base64 = { version = "0.13.0" }
 
 [features]
+default = ["reqwest/default"]
 test-helper = ["httpmock", "openssl", "rand", "base64"]
 rustls-tls = ["reqwest/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonwebtoken-google"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Kviring Aleksey <alex@kviring.com>"]
 edition = "2018"
 description = "parse and validate google jwt token with jsonwebtoken"
@@ -16,11 +16,12 @@ repository = "https://github.com/cheetah-games/jsonwebtoken-google"
 [dependencies]
 jsonwebtoken = "7.2.0"
 serde = { version = "1.0", features = ["derive"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 headers = "0.3.1"
 tokio = "1.0"
 httpmock = { version = "0.6.2", optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
+rustls = {version = "0.20.2", optional = true}
 rand = { version = "0.8.3", optional = true }
 base64 = { version = "0.13.0", optional = true }
 thiserror = "1.0.30"
@@ -33,3 +34,4 @@ base64 = { version = "0.13.0" }
 
 [features]
 test-helper = ["httpmock", "openssl", "rand", "base64"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
For our use case, the openssl requirement is problematic. This PR will allow us to use the upstream repository using the feature flag.