### PR TITLE
chore(deps): Update rsa requirement from 0.5.0 to 0.8.2 and fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ httpmock = { version = "0.6.2", optional = true }
 rustls = { version = "0.20.2" }
 base64 = { version = "0.13.0", optional = true }
 thiserror = "1.0.30"
-rsa = "0.5.0"
+rsa = "0.8.2"
 rand = "0.8.5"
 
 [dev-dependencies]


### PR DESCRIPTION
Can't use your library in my project because of version conflicts related to rsa dependency, so this PR updates it and also fixes tests compilation errors.

```
    Updating crates.io index
error: failed to select a version for `zeroize`.
    ... required by package `rsa v0.5.0`
    ... which satisfies dependency `rsa = "^0.5.0"` of package `jsonwebtoken-google v0.1.6`
    ... which satisfies dependency `jsonwebtoken-google = "^0.1.6"` of package `MY PACKAGE)`
versions that meet the requirements `>=1, <1.5` are: 1.4.3, 1.4.2, 1.4.1, 1.4.0, 1.3.0, 1.2.0, 1.1.1, 1.1.0, 1.0.0

all possible versions conflict with previously selected packages.

  previously selected package `zeroize v1.5.3`
    ... which satisfies dependency `zeroize = "^1.5"` of package `der v0.6.0`
    ... which satisfies dependency `der = "^0.6"` of package `ecdsa v0.14.4`
    ... which satisfies dependency `ecdsa-core = "^0.14"` of package `k256 v0.11.2`
    ... which satisfies dependency `k256 = "^0.11"` of package `coins-bip32 v0.7.0`
    ... which satisfies dependency `coins-bip32 = "^0.7.0"` of package `coins-bip39 v0.7.0`
    ... which satisfies dependency `coins-bip39 = "^0.7.0"` of package `ethers-signers v1.0.0`
    ... which satisfies dependency `ethers-signers = "^1.0.0"` of package `ethers v1.0.2`
    ... which satisfies dependency `ethers = "^1.0.2"` of package `MY PACKAGE`
```